### PR TITLE
refactor application status and job application entities

### DIFF
--- a/src/main/java/bwg/jobTracker/job_tracker/MapperUtil.java
+++ b/src/main/java/bwg/jobTracker/job_tracker/MapperUtil.java
@@ -3,16 +3,15 @@ package bwg.jobTracker.job_tracker;
 import bwg.jobTracker.job_tracker.dto.*;
 import bwg.jobTracker.job_tracker.entity.*;
 
-import java.util.stream.Collectors;
-
 public class MapperUtil {
 
     public static ApplicationStatusDTO toApplicationStatusDTO(ApplicationStatus status) {
         return new ApplicationStatusDTO(
                 status.getId(),
-                toJobApplicationDTO(status.getJobApplication()),
+                status.getJobApplication().getId(),
                 status.getApplicationStatusType(),
-                status.getActiveDate()
+                status.getActiveDate(),
+                status.getInactiveDate()
         );
     }
 
@@ -46,8 +45,8 @@ public class MapperUtil {
                 toJobPostingDTO(application.getJobPosting()),
                 application.getApplicationStatuses().stream()
                         .map(MapperUtil::toApplicationStatusDTO)
-                        .collect(Collectors.toSet()),
-                application.getCurrentStatusType(),
+                        .toList(),
+                application.getCurrentStatus().getId(),
                 application.getAppliedDate(),
                 application.getResumeFilename(),
                 application.getCoverLetterFilename()

--- a/src/main/java/bwg/jobTracker/job_tracker/dto/ApplicationStatusDTO.java
+++ b/src/main/java/bwg/jobTracker/job_tracker/dto/ApplicationStatusDTO.java
@@ -6,7 +6,8 @@ import java.time.LocalDate;
 
 public record ApplicationStatusDTO(
         Long id,
-        JobApplicationDTO jobApplication,
+        Long jobApplicationId,
         ApplicationStatusType applicationStatusType,
-        LocalDate activeDate
+        LocalDate activeDate,
+        LocalDate inactiveDate
 ) {}

--- a/src/main/java/bwg/jobTracker/job_tracker/dto/JobApplicationDTO.java
+++ b/src/main/java/bwg/jobTracker/job_tracker/dto/JobApplicationDTO.java
@@ -1,15 +1,13 @@
 package bwg.jobTracker.job_tracker.dto;
 
-import bwg.jobTracker.job_tracker.enums.ApplicationStatusType;
-
 import java.time.LocalDate;
-import java.util.Set;
+import java.util.List;
 
 public record JobApplicationDTO(
         Long id,
         JobPostingDTO jobPosting,
-        Set<ApplicationStatusDTO> applicationStatuses,
-        ApplicationStatusType currentStatusType,
+        List<ApplicationStatusDTO> applicationStatuses,
+        Long currentStatusId,
         LocalDate appliedDate,
         String resumeFilename,
         String coverLetterFilename

--- a/src/main/java/bwg/jobTracker/job_tracker/entity/ApplicationStatus.java
+++ b/src/main/java/bwg/jobTracker/job_tracker/entity/ApplicationStatus.java
@@ -19,6 +19,7 @@ public class ApplicationStatus {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "job_application_id")
+    @ToString.Exclude
     @NonNull private JobApplication jobApplication;
 
     @Enumerated(value = EnumType.STRING)
@@ -27,6 +28,9 @@ public class ApplicationStatus {
 
     @Column(name = "active_date")
     private LocalDate activeDate;
+
+    @Column(name = "inactive_date")
+    private LocalDate inactiveDate;
 
 
     @Version

--- a/src/main/resources/db/migration/V1__create_tables.sql
+++ b/src/main/resources/db/migration/V1__create_tables.sql
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS job_posting (
 CREATE TABLE IF NOT EXISTS job_application (
 	id BIGINT NOT NULL AUTO_INCREMENT,
 	job_posting_id BIGINT,
-	current_status_type VARCHAR(100),
+	current_status_id BIGINT,
 	applied_date DATE,
 	resume_filename VARCHAR(1000),
 	cover_letter_filename VARCHAR(1000),
@@ -48,9 +48,7 @@ CREATE TABLE IF NOT EXISTS job_application (
 
 	CONSTRAINT PK_JobApplication PRIMARY KEY (id),
 	CONSTRAINT FK_JobApplication_JobPostingId FOREIGN KEY (job_posting_id)
-		REFERENCES job_posting(id) ON UPDATE CASCADE,
-	CONSTRAINT CK_JobApplication_CurrentStatusType_enum
-		CHECK (current_status_type IN ('APPLIED', 'REJECTED', 'SCREENING', 'CODE_ASSESSMENT', 'INTERVIEWING'))
+		REFERENCES job_posting(id) ON UPDATE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS application_status (
@@ -58,6 +56,7 @@ CREATE TABLE IF NOT EXISTS application_status (
 	job_application_id BIGINT NOT NULL,
 	application_status_type VARCHAR(100) NOT NULL,
 	active_date DATE,
+	inactive_date DATE,
 	`VERSION` BIGINT,
 
 	CONSTRAINT PK_ApplicationStatus PRIMARY KEY (id),
@@ -66,6 +65,10 @@ CREATE TABLE IF NOT EXISTS application_status (
 	CONSTRAINT CK_ApplicationStatus_ApplicationStatusType_enum
 		CHECK (application_status_type IN ('APPLIED', 'REJECTED', 'SCREENING', 'CODE_ASSESSMENT', 'INTERVIEWING'))
 );
+
+ALTER TABLE job_application
+    ADD CONSTRAINT FK_JobApplication_CurrentStatusId FOREIGN KEY (current_status_id)
+        REFERENCES application_status(id) ON UPDATE CASCADE;
 
 CREATE TABLE IF NOT EXISTS interview (
 	id BIGINT NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
JobApplication carries just the ID of current applicationStatus rather than the full entity.
Replace full entity with just ID references for JobApplicationDTO.statuses; update flyway with FK constraint
* this should prevent the StackOverflow Error seen while writing unit tests.
Add inactiveDate field to ApplicationStatus and DTO; add to Flyway script for table creation.
Logic on JobApplication to be the only source of managing inactiveDate for old statuses being replaced during updateStatus().